### PR TITLE
fix error in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ var bindings = bind(fragment, {
   })
 })
 
-document.appendChild(bind(data, bindings))
+document.body.appendChild(bind(data, bindings))
 ```
 
 The DOM will update if any of the bound keys are assigned.


### PR DESCRIPTION
Specify `document.body` when appending the output HTML